### PR TITLE
Update reverse move stats

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1113,7 +1113,7 @@ moves_loop: // When in check, search starts from here
               // castling moves, because they are coded as "king captures rook" and
               // hence break make_move(). (~5 Elo)
               else if (    type_of(move) == NORMAL
-                       && !pos.see_ge(make_move(to_sq(move), from_sq(move))))
+                       && !pos.see_ge(reverse_move(move)))
                   r -= 2 * ONE_PLY;
 
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
@@ -1602,6 +1602,9 @@ moves_loop: // When in check, search starts from here
     Thread* thisThread = pos.this_thread();
     thisThread->mainHistory[us][from_to(move)] << bonus;
     update_continuation_histories(ss, pos.moved_piece(move), to_sq(move), bonus);
+
+    if (type_of(pos.moved_piece(move)) != PAWN)
+        thisThread->mainHistory[us][from_to(reverse_move(move))] << -bonus;
 
     if (is_ok((ss-1)->currentMove))
     {

--- a/src/types.h
+++ b/src/types.h
@@ -442,6 +442,10 @@ constexpr Move make_move(Square from, Square to) {
   return Move((from << 6) + to);
 }
 
+constexpr Move reverse_move(Move m) {
+  return make_move(to_sq(m), from_sq(m));
+}
+
 template<MoveType T>
 constexpr Move make(Square from, Square to, PieceType pt = KNIGHT) {
   return Move(T + ((pt - KNIGHT) << 12) + (from << 6) + to);


### PR DESCRIPTION
For a good quiet non-pawn move consider the reverse move as bad
and update the main history with a negative stat bonus.

STC:
LLR: 2.95 (-2.94,2.94) [0.50,4.50]
Total: 19292 W: 4401 L: 4141 D: 10750
http://tests.stockfishchess.org/tests/view/5d7751d50ebc594e7864973c

LTC:
LLR: 2.95 (-2.94,2.94) [0.00,3.50]
Total: 111952 W: 18762 L: 18275 D: 74915
http://tests.stockfishchess.org/tests/view/5d7771cf0ebc594e786498fa

Closes https://github.com/official-stockfish/Stockfish/pull/2294

Bench: 3914238